### PR TITLE
update-keychain-management

### DIFF
--- a/O3/Onboarding/LoginTableViewController.swift
+++ b/O3/Onboarding/LoginTableViewController.swift
@@ -46,8 +46,8 @@ class LoginTableViewController: UITableViewController, QRScanDelegate {
             do {
                 try keychain
                     .accessibility(.whenPasscodeSetThisDeviceOnly, authenticationPolicy: .userPresence)
-                    .set((Authenticated.account?.wif)!, key: "ozonePrivateKey")
-                self.performSegue(withIdentifier: "segueToMainFromLogin", sender: nil)
+                    .set(account.wif, key: "ozonePrivateKey")
+                DispatchQueue.main.async { self.performSegue(withIdentifier: "segueToMainFromLogin", sender: nil) }
                 Channel.shared().subscribe(toTopic: account.address)
             } catch let error {
                 fatalError("Unable to store private key in keychain \(error.localizedDescription)")

--- a/O3/Onboarding/LoginTableViewController.swift
+++ b/O3/Onboarding/LoginTableViewController.swift
@@ -10,6 +10,7 @@ import Foundation
 import UIKit
 import NeoSwift
 import Channel
+import KeychainAccess
 
 class LoginTableViewController: UITableViewController, QRScanDelegate {
     @IBOutlet weak var wifTextField: UITextView!
@@ -40,12 +41,22 @@ class LoginTableViewController: UITableViewController, QRScanDelegate {
         guard let account = Account(wif: self.wifTextField.text ?? "") else {
             return
         }
+        let keychain = Keychain(service: "network.o3.neo.wallet")
+        DispatchQueue.global().async {
+            do {
+                try keychain
+                    .accessibility(.whenPasscodeSetThisDeviceOnly, authenticationPolicy: .userPresence)
+                    .set((Authenticated.account?.wif)!, key: "ozonePrivateKey")
+                self.performSegue(withIdentifier: "segueToMainFromLogin", sender: nil)
+                Channel.shared().subscribe(toTopic: account.address)
+            } catch let error {
+                fatalError("Unable to store private key in keychain \(error.localizedDescription)")
+            }
+        }
         Authenticated.account = account
         //subscribe to a topic which is an address to receive push notification
-        Channel.shared().subscribe(toTopic: account.address)
         //enable push notifcation. maybe put this in somewhere else?
         Channel.pushNotificationEnabled(true)
-        self.performSegue(withIdentifier: "segueToMainFromLogin", sender: nil)
     }
 
     @objc func qrScanTapped(_ sender: Any) {

--- a/O3/Onboarding/WelcomeTableViewController.swift
+++ b/O3/Onboarding/WelcomeTableViewController.swift
@@ -13,7 +13,6 @@ import KeychainAccess
 class WelcomeTableViewController: UITableViewController {
     @IBOutlet weak var privateKeyQR: UIImageView!
     @IBOutlet weak var privateKeyLabel: UILabel!
-    let keychain = Keychain(service: "network.o3.wallet")
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,9 +21,10 @@ class WelcomeTableViewController: UITableViewController {
         self.privateKeyQR.image = UIImage(qrData: Authenticated.account?.wif ?? "", width: self.privateKeyQR.frame.width, height: self.privateKeyQR.frame.height)
         self.privateKeyLabel.text = Authenticated.account?.wif ?? ""
 
+        let keychain = Keychain(service: "network.o3.neo.wallet")
         DispatchQueue.global().async {
             do {
-                try self.keychain
+                try keychain
                     .accessibility(.whenPasscodeSetThisDeviceOnly, authenticationPolicy: .userPresence)
                     .set((Authenticated.account?.wif)!, key: "ozonePrivateKey")
             } catch let error {
@@ -38,24 +38,6 @@ class WelcomeTableViewController: UITableViewController {
     }
 
     @IBAction func startTapped(_ sender: Any) {
-        DispatchQueue.main.async {
-
-        }
-        DispatchQueue.global().async {
-            do {
-                let password = try self.keychain
-                    .authenticationPrompt("Authenticate to view your private key")
-                    .get("ozonePrivateKey")
-
-            } catch let error {
-                fatalError("Unable to store private key in keychain \(error.localizedDescription)")
-            }
-        }
+       self.performSegue(withIdentifier: "segueToMainFromWelcome", sender: nil)
     }
 }
-
-        //DispatchQueue.global().async {
-        //    print (keychain["ozonePrivateKey"])
-            //self.performSegue(withIdentifier: "segueToMainFromWelcome", sender: nil)
-        //}
- //   }

--- a/O3/Send/SendTableViewController.swift
+++ b/O3/Send/SendTableViewController.swift
@@ -56,7 +56,7 @@ class SendTableViewController: UITableViewController, AddressSelectDelegate, QRS
         DispatchQueue.main.async {
             let message = "Are you sure you want to send \(amount) \(assetName) to \(toAddress)"
             OzoneAlert.confirmDialog(message: message, cancelTitle: "Cancel", confirmTitle: "Confirm", didCancel: {}) {
-                let keychain = Keychain(service: "network.o3.wallet")
+                let keychain = Keychain(service: "network.o3.neo.wallet")
                 DispatchQueue.global().async {
                     do {
                         let password = try keychain

--- a/O3/Send/SendTableViewController.swift
+++ b/O3/Send/SendTableViewController.swift
@@ -66,7 +66,6 @@ class SendTableViewController: UITableViewController, AddressSelectDelegate, QRS
                             self.transactionCompleted = completed ?? false
                             DispatchQueue.main.async {
                                 self.performSegue(withIdentifier: "segueToTransactionComplete", sender: nil)
-
                             }
                         }
                     } catch let error {

--- a/O3/SettingsMenu/SettingsMenuTableViewController.swift
+++ b/O3/SettingsMenu/SettingsMenuTableViewController.swift
@@ -19,11 +19,15 @@ class SettingsMenuTableViewController: UITableViewController, HalfModalPresentab
 
     var netString = Neo.isTestnet ? "Network: Test Network": "Network: Main Network" {
         didSet {
-            guard let label = networkCell.viewWithTag(1) as? UILabel else {
-                fatalError("Undefined behavior with table view")
-            }
-            DispatchQueue.main.async { label.text = self.netString }
+            self.setNetLabel()
         }
+    }
+
+    func setNetLabel() {
+        guard let label = networkCell.viewWithTag(1) as? UILabel else {
+            fatalError("Undefined behavior with table view")
+        }
+        DispatchQueue.main.async { label.text = self.netString }
     }
 
     override func viewDidLoad() {
@@ -35,7 +39,7 @@ class SettingsMenuTableViewController: UITableViewController, HalfModalPresentab
         contactView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(sendMail)))
         shareView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(share)))
         networkView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(changeNetwork)))
-
+        setNetLabel()
     }
 
     @objc func maximize(_ sender: Any) {
@@ -86,7 +90,7 @@ class SettingsMenuTableViewController: UITableViewController, HalfModalPresentab
     }
 
     @objc func showPrivateKey() {
-        let keychain = Keychain(service: "network.o3.wallet")
+        let keychain = Keychain(service: "network.o3.neo.wallet")
         DispatchQueue.global().async {
             do {
                 let password = try keychain
@@ -97,7 +101,7 @@ class SettingsMenuTableViewController: UITableViewController, HalfModalPresentab
                 }
 
             } catch let error {
-               // fatalError("Unable to store private key in keychain \(error.localizedDescription)")
+
             }
         }
     }


### PR DESCRIPTION
New flow is this, if logging in or creating a privatekey for the first time (no ozone private key in the keychain already) there is no prompt.

If they try to login again or create a new private key, touch id authentication is asked for. There should be some sort of additional dialog to say that a login with another private key or creating a new key WILL DESTROY the old key in the keychain